### PR TITLE
sentry 8.10.0 + sentry-plugins (#1)

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs
+https://github.com/heroku/heroku-buildpack-python

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "detect-node",
+  "version": "0.0.1",
+  "engines": {
+    "node": "6.9.1",
+    "npm": "3.10.8"
+  },
+  "scripts": {
+     "start": "node -v && npm -v"
+  }
+}

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,8 @@ django-secure
 django-storages
 ndg-httpsclient  # required by requests
 psycopg2
-sentry
+sentry==8.10.0
 sentry-auth-google
-sentry-github
+twisted
+sentry-plugins
+ 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,13 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
+BeautifulSoup==3.2.1      # via sentry-plugins
 billiard==3.3.0.23        # via celery
+boto3==1.4.1              # via sentry
 boto==2.43.0
+botocore==1.4.69          # via boto3, s3transfer
 celery==3.1.18            # via sentry
-cffi==1.8.3               # via cryptography, symsynd
+cffi==1.8.3               # via cryptography, libsourcemap, symsynd
 click==6.6                # via sentry
 contextlib2==0.5.4        # via raven
 cryptography==1.5.2       # via pyopenssl, python-u2flib-server
@@ -28,19 +31,24 @@ django-sudo==2.1.0        # via sentry
 django-templatetag-sugar==1.0  # via sentry
 Django==1.6.11            # via django-bitfield, django-debug-toolbar, django-secure, sentry
 djangorestframework==2.3.14  # via sentry
+docutils==0.12            # via botocore
 email-reply-parser==0.2.0  # via sentry
 enum34==1.1.6             # via cryptography, python-u2flib-server, sentry
 exam==0.10.6              # via sentry
+futures==3.0.5            # via s3transfer
 hiredis==0.1.6            # via sentry
 honcho==0.7.1             # via sentry
 httplib2==0.9.2           # via oauth2
 idna==2.1                 # via cryptography
 ipaddress==1.0.17         # via cryptography, sentry
+jmespath==0.9.0           # via boto3, botocore
 kombu==3.0.35             # via celery, sentry
+libsourcemap==0.5.0       # via sentry
 lxml==3.6.4               # via sentry, toronado
 mock==1.0.1               # via exam, sentry
 ndg-httpsclient==0.4.2
 oauth2==1.9.0.post1       # via sentry
+oauthlib==2.0.0           # via requests-oauthlib
 percy==0.4.1              # via sentry
 petname==1.7              # via sentry
 Pillow==3.2.0             # via sentry
@@ -50,11 +58,12 @@ py-bcrypt==0.4            # via django-bcrypt
 py==1.4.31                # via pytest
 pyasn1==0.1.9             # via cryptography, requests
 pycparser==2.16           # via cffi
+PyJWT==1.4.2              # via sentry-plugins
 PyOpenSSL==16.2.0         # via ndg-httpsclient, requests
 pytest-django==2.9.1      # via sentry
 pytest-html==1.9.0        # via sentry
 pytest==2.6.4             # via pytest-django, pytest-html, sentry
-python-dateutil==2.5.3    # via sentry
+python-dateutil==2.5.3    # via botocore, sentry, sentry-plugins
 python-memcached==1.58    # via sentry
 python-openid==2.2.5      # via sentry
 python-u2flib-server==4.0.1  # via sentry
@@ -65,12 +74,13 @@ qrcode==5.3               # via sentry
 raven==5.31.0             # via sentry
 rb==1.5                   # via sentry
 redis==2.10.5             # via rb, sentry
-requests[security]==2.11.1  # via percy, sentry
-selenium==2.53.6          # via sentry
+requests-oauthlib==0.7.0  # via sentry-plugins
+requests[security]==2.11.1  # via percy, requests-oauthlib, sentry
+s3transfer==0.1.9         # via boto3
+selenium==3.0.0b3         # via sentry
 sentry-auth-google==0.1.0
-sentry-github==0.1.2
-sentry-jira==0.8.0
-sentry==8.9.0
+sentry-plugins==8.10.0
+sentry==8.10.0
 setproctitle==1.1.10      # via sentry
 simplejson==3.8.2         # via sentry
 six==1.10.0               # via cryptography, django-bitfield, pyopenssl, python-dateutil, python-memcached, python-utils, qrcode, sentry, structlog
@@ -80,10 +90,12 @@ statsd==3.1               # via sentry
 structlog==16.1.0         # via sentry
 symsynd==1.2.0            # via sentry
 toronado==0.0.11          # via sentry
+twisted==16.4.1
 ua-parser==0.7.1          # via sentry
 urllib3==1.16             # via sentry
-twisted==16.3.0
+uwsgi==2.0.14             # via sentry
+zope.interface==4.3.2     # via twisted
 
 # The following packages are commented out because they are
 # considered to be unsafe in a requirements file:
-# setuptools                # via cryptography
+# setuptools                # via cryptography, zope.interface


### PR DESCRIPTION
Update to sentry 8.10.0 and the first release of sentry-plugins

https://github.com/getsentry/sentry-plugins/releases/tag/8.10.0